### PR TITLE
Add (limited) tls-attacker regression endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It is fashioned after the [QUIC Interop Runner](https://github.com/marten-seeman
 
 1. `make certs`
 2. `make dc` (TODO: Flesh out testing API to remove this step)
-3. `env SERVER={rustls|boringssl} CLIENT=cloudflare-go docker-compose build`
-4. `env SERVER={rustls|boringssl} CLIENT=cloudflare-go docker-compose up`
+3. `env SERVER_SRC=./impl-endpoints SERVER={rustls|boringssl} CLIENT_SRC=./impl-endpoints CLIENT=cloudflare-go docker-compose build`
+4. `env SERVER_SRC=./impl-endpoints SERVER={rustls|boringssl} CLIENT_SRC=./impl-endpoints CLIENT=cloudflare-go docker-compose up`
 
 set `SERVER=boringssl` for delegated credential tests.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "2.4"
 services:
   server:
     image: ${SERVER}
-    build: ./impl-endpoints/${SERVER}
+    build: ${SERVER_SRC}/${SERVER}
     container_name: server
     hostname: server
     stdin_open: true
@@ -18,10 +18,11 @@ services:
       - interopnet
     environment:
       - TESTCASE=${TESTCASE}
+      - ROLE=server
 
   client:
     image: ${CLIENT}
-    build: ./impl-endpoints/${CLIENT}
+    build: ${CLIENT_SRC}/${CLIENT}
     container_name: client
     hostname: client
     stdin_open: true
@@ -36,6 +37,7 @@ services:
       - interopnet
     environment:
       - TESTCASE=${TESTCASE}
+      - ROLE=client
 
 networks:
   interopnet:

--- a/regression-endpoints/tls-attacker/Dockerfile
+++ b/regression-endpoints/tls-attacker/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:latest
+
+RUN apt update -y
+RUN apt-get update && \
+    apt-get install -y openjdk-8-jdk && \
+    apt-get install -y ant && \
+    apt-get install maven -y && \
+    apt-get install git -y && \
+    apt-get clean;
+
+# RUN update-alternatives --config java
+
+RUN git clone https://github.com/tls-attacker/TLS-Attacker.git /tls-attacker
+RUN git clone https://github.com/tls-attacker/ASN.1-Tool.git /asn1-tool
+RUN git clone https://github.com/tls-attacker/X509-Attacker.git /x509-attacker
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
+RUN export JAVA_HOME
+
+WORKDIR /asn1-tool
+RUN mvn clean install
+
+WORKDIR /x509-attacker
+RUN mvn clean install
+
+WORKDIR /tls-attacker
+RUN mvn clean install -DskipTests=true
+
+WORKDIR /tls-attacker/resources
+RUN chmod +x keygen.sh
+RUN ./keygen.sh && cp *.pem ../apps
+
+COPY run_endpoint.sh /run_endpoint.sh
+RUN chmod +x /run_endpoint.sh
+
+ENTRYPOINT [ "/run_endpoint.sh" ]

--- a/regression-endpoints/tls-attacker/run_endpoint.sh
+++ b/regression-endpoints/tls-attacker/run_endpoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+if [ "$ROLE" = "client" ]; then
+    echo "Running tls-attacker client."
+    echo "Server params: $CLIENT_PARAMS"
+    echo "Test case: $TESTCASE"
+
+    cd /tls-attacker/apps
+    # java -jar Attacks.jar padding_oracle -connect server:4433
+    # java -jar TLS-Client.jar -connect server:4433 -cipher TLS_RSA_WITH_AES_256_CBC_SHA -version TLS11
+    java -jar TLS-Client.jar -connect server:4433 -cipher TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 -version TLS12
+else
+    echo "Running tls-attacker server."
+    echo "Server params: $SERVER_PARAMS"
+    echo "Test case: $TESTCASE"
+
+    cd /tls-attacker/apps
+    java -jar TLS-Server.jar -port 4433
+fi


### PR DESCRIPTION
This does not run the server (yet), due to certificate configuration issues. We need to sort them out with the project (hopefully without forking!). It also does not run explicit attacks, yet. It's not clear what are the semantics of those attack variants, e.g., whether they need to run multiple connections back-to-back, or if they only require one attack to run. I'll file an issue on the [TLS-Attacker](https://github.com/tls-attacker/TLS-Attacker) repository to work through these concerns. But, for now, this gets us started.