### PR TITLE
Revise Makefile and build instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ cert-tool: $(CERT_TOOL_FILES)
 .PHONY: certs
 certs: cert-tool
 	rm -rf certs && mkdir certs
-	cert-tool -make-root -out certs/rootCA.pem -key-out certs/rootCA.key
-	cert-tool -make-intermediate -cert-in certs/rootCA.pem -key-in certs/rootCA.key -out certs/server.cert -key-out certs/server.key
+	./cert-tool -make-root -out certs/rootCA.pem -key-out certs/rootCA.key
+	./cert-tool -make-intermediate -cert-in certs/rootCA.pem -key-in certs/rootCA.key -out certs/server.cert -key-out certs/server.key
 
 dc: certs/server.cert certs/server.key cert-tool
-	cert-tool -make-dc -cert-in certs/server.cert -key-in certs/server.key -out certs/dc.txt
+	./cert-tool -make-dc -cert-in certs/server.cert -key-in certs/server.key -out certs/dc.txt
 
 clean:
 	docker builder prune

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ It is fashioned after the [QUIC Interop Runner](https://github.com/marten-seeman
 
 ## Quickstart
 
+Clone this repository into $GOPATH/src/github.com/xvzcf/tls-interop-runner, then run the following commands:
+
 1. `make certs`
 2. `make dc` (TODO: Flesh out testing API to remove this step)
 3. `env SERVER_SRC=./impl-endpoints SERVER={rustls|boringssl} CLIENT_SRC=./impl-endpoints CLIENT=cloudflare-go docker-compose build`


### PR DESCRIPTION
I tested the build instructions to make sure the tests run smoothly on
Ubuntu. I needed to make some minor changes to the Makefile to get
things working. It's also worth noting that you need to be in the
$GOPATH in order to fetch the dependencies for cert-tool.