### PR TITLE
Fix race condition in test runner

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,8 @@ services:
     environment:
       - TESTCASE=${TESTCASE}
       - ROLE=client
+    depends_on:
+      - server
 
 networks:
   interopnet:


### PR DESCRIPTION
It's possible for the client to attempt a TCP connection before the
server is listening. This change ensures that the server is started
before the client, which prevents this from happening.