### PR TITLE
dc testcase: Add no-op support for cloudflare-go server

### DIFF
--- a/impl-endpoints/cloudflare-go/Dockerfile
+++ b/impl-endpoints/cloudflare-go/Dockerfile
@@ -14,6 +14,8 @@ COPY --from=builder /cf-go /cf-go
 
 COPY runner.go /
 
+RUN /cf-go/bin/go build -o /usr/bin/runner runner.go
+
 COPY run_endpoint.sh /
 RUN chmod +x /run_endpoint.sh
 

--- a/impl-endpoints/cloudflare-go/run_endpoint.sh
+++ b/impl-endpoints/cloudflare-go/run_endpoint.sh
@@ -1,15 +1,14 @@
 #!/bin/sh
 set -e
 
-ROLE=client
-
 if [ "$ROLE" = "client" ]; then
-    # TODO
     echo "Running Cloudflare-Go client."
-    echo "Client params: $SERVER_PARAMS"
+    echo "Client params: $CLIENT_PARAMS"
     echo "Test case: $TESTCASE"
-    /cf-go/bin/go run /runner.go -role=client -test=${TESTCASE}
+    runner -role=client -test=${TESTCASE}
 else
-    true
-    # TODO
+    echo "Running Cloudflare-Go server."
+    echo "Server params: $SERVER_PARAMS"
+    echo "Test case: $TESTCASE"
+    runner -role=server -test=${TESTCASE}
 fi

--- a/impl-endpoints/cloudflare-go/runner.go
+++ b/impl-endpoints/cloudflare-go/runner.go
@@ -3,43 +3,119 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"flag"
 	"io/ioutil"
 	"log"
+	"net"
 	"os"
 )
 
+func createBaseClientConfig() (*tls.Config, error) {
+	certPool := x509.NewCertPool()
+	pem, err := ioutil.ReadFile("/certs/rootCA.pem")
+	if err != nil {
+		return nil, err
+	}
+	certPool.AppendCertsFromPEM(pem)
+	return &tls.Config{RootCAs: certPool}, nil
+}
+
+func createBaseServerConfig() (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair("/certs/server.cert", "/certs/server.key")
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Config{Certificates: []tls.Certificate{cert}}, nil
+}
+
 type testCase interface {
 	ClientConfig() (*tls.Config, error)
-	ClientConnectionHandler(*tls.Conn) bool
-	// ServerConfig() *tls.Config
-	// ServerListenerHandler(net.Listener) bool
+	ClientConnectionHandler(*tls.Conn) error
+	ServerConfig() (*tls.Config, error)
+	ServerConnectionHandler(*tls.Conn) error
 }
 
 type delegatedCredentialTestCase struct {
 }
 
 func (c delegatedCredentialTestCase) ClientConfig() (*tls.Config, error) {
-	certPool := x509.NewCertPool()
-	pem, err := ioutil.ReadFile("/certs/rootCA.pem")
+	config, err := createBaseClientConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	certPool.AppendCertsFromPEM(pem)
-	return &tls.Config{
-		RootCAs:                    certPool,
-		SupportDelegatedCredential: true,
-	}, nil
+	config.SupportDelegatedCredential = true
+	return config, nil
 }
 
-func (c delegatedCredentialTestCase) ClientConnectionHandler(conn *tls.Conn) bool {
-	state := conn.ConnectionState()
-	return state.VerifiedDC != nil
+func (c delegatedCredentialTestCase) ClientConnectionHandler(conn *tls.Conn) error {
+	if conn.ConnectionState().VerifiedDC == nil {
+		return errors.New("Failed to verify a delegated credential")
+	}
+	return nil
+}
+
+func (c delegatedCredentialTestCase) ServerConfig() (*tls.Config, error) {
+	config, err := createBaseServerConfig()
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
+}
+
+func (c delegatedCredentialTestCase) ServerConnectionHandler(conn *tls.Conn) error {
+	// TODO
+	return errors.New("NOT IMPLEMENTED")
 }
 
 var testCaseHandlers = map[string]testCase{
 	"dc": delegatedCredentialTestCase{},
+}
+
+func doClient(t testCase) error {
+	config, err := t.ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	c, err := tls.Dial("tcp", "server:4433", config)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+	log.Print("Handshake completed")
+
+	return t.ClientConnectionHandler(c)
+}
+
+func doServer(t testCase) error {
+	config, err := t.ServerConfig()
+	if err != nil {
+		return err
+	}
+
+	ln, err := net.Listen("tcp", ":4433")
+	if err != nil {
+		return err
+	}
+	defer ln.Close()
+	log.Print("Listening at ", ln.Addr())
+
+	conn, err := ln.Accept()
+	if err != nil {
+		return err
+	}
+
+	s := tls.Server(conn, config)
+	err = s.Handshake()
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+	log.Print("Handshake completed")
+
+	return t.ServerConnectionHandler(s)
 }
 
 func main() {
@@ -54,23 +130,14 @@ func main() {
 	}
 
 	if *role == "client" {
-		config, err := handler.ClientConfig()
-		if err != nil {
-			log.Fatal(err)
-			return
+		if err := doClient(handler); err != nil {
+			log.Fatal("Error: ", err)
 		}
-
-		conn, err := tls.Dial("tcp", "server:4433", config)
-		if err != nil {
-			log.Fatal(err)
-			return
-		}
-		defer conn.Close()
-
-		if !handler.ClientConnectionHandler(conn) {
-			os.Exit(-1)
+	} else if *role == "server" {
+		if err := doServer(handler); err != nil {
+			log.Fatal("Error: ", err)
 		}
 	} else {
-		panic("Server role not implemented")
+		log.Fatalf("unknown role \"%s\"", *role)
 	}
 }


### PR DESCRIPTION
This change refactors the cloudflare-go runner and adds server support.
It also provides rudimentary support for the "dc" test case; the server
is run, but it currently doesn't configure a DC.

This change also modifies the Dockerfile for cloudflare-go so that the
runner is built into the image, rather than interpreted on the fly. This
ensures that a client-side build error doesn't cause the server to hang.