### PR TITLE
Clean up build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,39 @@
 # (Work in Progress) TLS Interop Test Runner
 
-The TLS Interop Test Runner aims to test interoperability between implementations of TLS by running various tests involving clients and servers drawn from differing implementations.
+The TLS Interop Test Runner aims to test interoperability between
+implementations of TLS by running various tests involving clients and servers
+drawn from differing implementations.
 
-It is fashioned after the [QUIC Interop Runner](https://github.com/marten-seemann/quic-interop-runner).
+It is fashioned after the [QUIC Interop
+Runner](https://github.com/marten-seemann/quic-interop-runner).
 
 ## Quickstart
 
-Clone this repository into $GOPATH/src/github.com/xvzcf/tls-interop-runner, then run the following commands:
+Tests are run with `docker-compose`. To run a test, you must first build the
+endpoints. For example, to build a boringSSL server and Cloudflare-Go client:
 
-1. `make certs`
-2. `make dc` (TODO: Flesh out testing API to remove this step)
-3. `env SERVER_SRC=./impl-endpoints SERVER={rustls|boringssl} CLIENT_SRC=./impl-endpoints CLIENT=cloudflare-go docker-compose build`
-4. `env SERVER_SRC=./impl-endpoints SERVER={rustls|boringssl} CLIENT_SRC=./impl-endpoints CLIENT=cloudflare-go docker-compose up`
+```
+env SERVER_SRC=./impl-endpoints SERVER=boringssl \
+    CLIENT_SRC=./impl-endpoints CLIENT=cloudflare-go \
+    docker-compose build
+```
 
-set `SERVER=boringssl` for delegated credential tests.
+Tests require certificates and other cryptographic artifacts to be generated
+beforehand. To do so, you will need to have Go installed and make sure this
+repository is in your $GOPATH (e.g.,
+~/go/src/github.com/xvzcf/tls-interop-runner).
+
+```
+make certs
+make dc
+```
+
+You're now ready to run tests. The test case is also specified by setting an
+environment variable. For example, to run the server-side delegated credential
+test:
+
+```
+env SERVER_SRC=./impl-endpoints SERVER=boringssl \
+    CLIENT_SRC=./impl-endpoints CLIENT=cloudflare-go \
+    TESTCASE=dc docker-compose up
+```


### PR DESCRIPTION
Explains that the test case is specified by an environment variable
and clarifies the requirements for running cert-tool.