### PR TITLE
"ech-accept" test case

### DIFF
--- a/cmd/util/ech.go
+++ b/cmd/util/ech.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	ECHVersionDraft09 uint16 = 0xff09 // draft-ietf-tls-esni-09
+	ECHVersionDraft09 uint16 = 0xfe09 // draft-ietf-tls-esni-09
 )
 
 // ECHConfigTemplate defines the parameters for generating an ECH config and
@@ -83,7 +83,7 @@ func GenerateECHKey(template ECHConfigTemplate) (*ECHKey, error) {
 
 	secretKey, err := sk.MarshalBinary()
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal KEM secert key: %s", err)
+		return nil, fmt.Errorf("failed to marshal KEM secret key: %s", err)
 	}
 
 	var c cryptobyte.Builder


### PR DESCRIPTION
Based on #19.
DO NOT MERGE until #19 has been merged.

Adds client and server support for the ECH extension to cloudflare-go.
The "ech-accept" test case, the client offers ECH and the server
accepts.

This PR also fixes the ECH codepoint in cmd/util, which was incorrect.