### PR TITLE
Add "ech-reject" test case for nss and cloudflare-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ testinputs: util
 	${UTIL} -make-intermediate -cert-in ${TESTDATA_DIR}/root.crt -key-in ${TESTDATA_DIR}/root.key -out ${TESTDATA_DIR}/client-facing.crt -key-out ${TESTDATA_DIR}/client-facing.key -host client-facing.com
 	${UTIL} -make-dc -cert-in ${TESTDATA_DIR}/example.crt -key-in ${TESTDATA_DIR}/example.key -out ${TESTDATA_DIR}/dc.txt
 	${UTIL} -make-ech -out ${TESTDATA_DIR}/ech_configs -key-out ${TESTDATA_DIR}/ech_key -host client-facing.com
+	${UTIL} -make-ech -out ${TESTDATA_DIR}/ech_configs_invalid -key-out /dev/null -host client-facing.com
 
 clean:
 	rm -fr ${BIN_DIR}

--- a/impl-endpoints/cloudflare-go/run_endpoint.sh
+++ b/impl-endpoints/cloudflare-go/run_endpoint.sh
@@ -9,12 +9,10 @@ sh /setup-routes.sh
 
 if [ "$ROLE" = "client" ]; then
     echo "Running Cloudflare-Go client."
-    echo "Client params: $CLIENT_PARAMS"
     echo "Test case: $TESTCASE"
     runner -role=client -test=${TESTCASE}
 else
     echo "Running Cloudflare-Go server."
-    echo "Server params: $SERVER_PARAMS"
     echo "Test case: $TESTCASE"
     runner -role=server -test=${TESTCASE}
 fi

--- a/impl-endpoints/nss/run_endpoint.sh
+++ b/impl-endpoints/nss/run_endpoint.sh
@@ -13,7 +13,7 @@ PORT=4433
 rm -rf nss_testdata
 mkdir nss_testdata
 
-if [ "$TESTCASE" = "ech-accept" ]; then
+if [ "$TESTCASE" = "ech-accept" ] || [ "$TESTCASE" = "ech-reject" ]; then
     # Create a PKCS8 file for the ECH keypair
     python3 /ech_key_converter.py /test-inputs/ech_key nss_testdata/ech_key_converted
 
@@ -42,9 +42,24 @@ if [ "$ROLE" = "client" ]; then
     echo "Running NSS client."
     echo "Client params: $SERVER_PARAMS"
     echo "Test case: $TESTCASE"
-    ECH_CONFIGS=$(<testdata/ech_configs)
     echo "GET / HTTP/1.0" > req.txt
-    tstclnt -d "$DB_DIR" -h example.com -p "$PORT" -N "$ECH_CONFIGS" -A req.txt
+    if [ "$TESTCASE" = "ech-reject" ]; then
+      ECH_CONFIGS=$(</test-inputs/ech_configs_invalid)
+
+      # Default cert verifier (which is used by tstclnt) is not ECH-aware.
+      # Override failures since the hostnames won't match.
+      tstclnt -d "$DB_DIR" -h example.com -p "$PORT" -N "$ECH_CONFIGS" -A req.txt -o &> err.txt || true
+      ECH_CONFIGS=$(sed '4q;d' err.txt)
+      if [ "$ECH_CONFIGS" != "$(</test-inputs/ech_configs)" ]; then
+        echo "Unexpected error:"
+        cat err.txt
+      else
+        echo "Aborted the connection as expected"
+      fi
+    else
+      ECH_CONFIGS=$(</test-inputs/ech_configs)
+      tstclnt -d "$DB_DIR" -h example.com -p "$PORT" -N "$ECH_CONFIGS" -A req.txt
+    fi
 else
     echo "Running NSS server."
     echo "Server params: $SERVER_PARAMS"


### PR DESCRIPTION
Partially addresses #27.

Adds a test case for exercising the ECH rejection path, with initial support for NSS and Cloudflare-Go.

In this test case, the client offers ECH with an invalid config, the server rejects, and the client aborts the connection with "ech_required" alert. They don't attempt to retry the connection with the retry configs.

Thanks to @kjacobs-moz for help getting the NSS client endpoint right!