### PR TITLE
Ensure all servers run forever

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,6 @@ You will need to have golang installed.
 You will need to clone this repository on the `src` directory of your
 `$GOPATH`. To learn your `$GOPATH`, use `go env`.
 
-Tests are run with `docker-compose`. To run a test, you must first build the
-endpoints. For example, to build a boringSSL server and Cloudflare-Go client:
-
-```
-env SERVER_SRC=./impl-endpoints SERVER=boringssl \
-    CLIENT_SRC=./impl-endpoints CLIENT=cloudflare-go \
-    docker-compose build
-```
-
 Tests require certificates and other cryptographic artifacts to be generated
 beforehand.
 
@@ -39,12 +30,18 @@ This command will generate:
 * A delegated credential
 * ECH configuration files
 
+Tests are run with `docker-compose`, with the artifacts copied into a virtual
+volume. To run a test, you must first build the endpoints. For example, to build
+a boringSSL server and Cloudflare-Go client:
+
+```
+./build.sh cloudflare-go boringssl
+```
+
 You're now ready to run tests. The test case is also specified by setting an
 environment variable. For example, to run the server-side delegated credential
 test:
 
 ```
-env SERVER_SRC=./impl-endpoints SERVER=boringssl \
-    CLIENT_SRC=./impl-endpoints CLIENT=cloudflare-go \
-    TESTCASE=dc docker-compose up
+./run.sh cloudflare-go boringssl dc
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This command will generate:
 
 Tests are run with `docker-compose`, with the artifacts copied into a virtual
 volume. To run a test, you must first build the endpoints. For example, to build
-a boringSSL server and Cloudflare-Go client:
+a BoringSSL server and Cloudflare-Go client:
 
 ```
 ./build.sh cloudflare-go boringssl

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ "$#" -ne 2 ]; then
+    echo "usage: $0 <client> <server>"
+    echo
+    echo "where <client> and <server> are one of the following:"
+    echo "boringssl, cloudflare-go, nss, rustls"
+    exit 1
+fi
+
+env SERVER_SRC=./impl-endpoints SERVER=$2 \
+    CLIENT_SRC=./impl-endpoints CLIENT=$1 \
+    docker-compose build

--- a/impl-endpoints/boringssl/run_endpoint.sh
+++ b/impl-endpoints/boringssl/run_endpoint.sh
@@ -14,5 +14,5 @@ else
     echo "Running BoringSSL server."
     echo "Server params: $SERVER_PARAMS"
     echo "Test case: $TESTCASE"
-    bssl server -accept 4433 -cert /test-inputs/example.crt -key /test-inputs/example.key -subcert /test-inputs/dc.txt
+    bssl server -loop -accept 4433 -cert /test-inputs/example.crt -key /test-inputs/example.key -subcert /test-inputs/dc.txt
 fi

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# After typing Ctrl-C, Docker waits this number of seconds to interrupt the
+# containers.
+TIMEOUT=0
+
+if [ "$#" -ne 3 ]; then
+    echo "usage: $0 <client> <server> <testcase>"
+    echo
+    echo "where <client> and <server> are one of the following:"
+    echo "boringssl, cloudflare-go, nss, rustls"
+    echo
+    echo "and <testcase> is one of the following:"
+    echo "dc, ech-accept, ech-reject"
+    exit 1
+fi
+
+env SERVER_SRC=./impl-endpoints SERVER=$2 \
+    CLIENT_SRC=./impl-endpoints CLIENT=$1 \
+    TESTCASE=$3 \
+    docker-compose up --timeout $TIMEOUT
+
+docker-compose stop


### PR DESCRIPTION
Partially addresses #27.

The scope of each test case is a single connection attempt. BoringSSL and Cloudflare-Go servers quit after one connection attempt, but the NSS and rustls servers listen forever. This change ensures that all of the servers run forever so that the code that calls `docker-compose up` is responsible for timing out.