### PR TITLE
Upgrade ECH target to draft-ietf-tls-esni-10

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ "$#" -ne 2 ]; then
+    echo "usage: $0 <client> <server>"
+    echo
+    echo "where <client> and <server> are one of the following:"
+    echo "boringssl, cloudflare-go, nss, rustls"
+    exit 1
+fi
+
+env SERVER_SRC=./impl-endpoints SERVER=$2 \
+    CLIENT_SRC=./impl-endpoints CLIENT=$1 \
+    docker-compose build

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -113,8 +113,9 @@ func main() {
 	} else if *makeECH {
 		err = utils.MakeECHKey(
 			utils.ECHConfigTemplate{
+				Id:         123, // This is chosen at random by the client-facing server.
 				PublicName: *hostName,
-				Version:    utils.ECHVersionDraft09,
+				Version:    utils.ECHVersionDraft10,
 				KemId:      uint16(hpke.KEM_X25519_HKDF_SHA256),
 				KdfIds: []uint16{
 					uint16(hpke.KDF_HKDF_SHA256),

--- a/impl-endpoints/cloudflare-go/Dockerfile
+++ b/impl-endpoints/cloudflare-go/Dockerfile
@@ -5,10 +5,10 @@ FROM golang:latest AS builder
 
 RUN apt-get update && \
     apt-get install git
-RUN git clone https://github.com/cloudflare/go /cf
+RUN git clone --branch caw/ech-10 https://github.com/cloudflare/go /cf
 
 WORKDIR /cf/src
-RUN git checkout 2a17ea31d28264fccfec4e59dc2ac733b6c73dec
+# RUN git checkout 2a17ea31d28264fccfec4e59dc2ac733b6c73dec
 RUN ./make.bash
 
 FROM ubuntu:20.04

--- a/impl-endpoints/cloudflare-go/Dockerfile
+++ b/impl-endpoints/cloudflare-go/Dockerfile
@@ -5,10 +5,10 @@ FROM golang:latest AS builder
 
 RUN apt-get update && \
     apt-get install git
-RUN git clone --branch caw/ech-10 https://github.com/cloudflare/go /cf
+RUN git clone --branch cf https://github.com/cloudflare/go /cf
 
 WORKDIR /cf/src
-# RUN git checkout 2a17ea31d28264fccfec4e59dc2ac733b6c73dec
+RUN git checkout 7c96cb688f153fcbd51bb2c2e2e38f85820ee5c7
 RUN ./make.bash
 
 FROM ubuntu:20.04

--- a/impl-endpoints/nss/Dockerfile
+++ b/impl-endpoints/nss/Dockerfile
@@ -22,8 +22,8 @@ RUN cd /build \
    && hg clone https://hg.mozilla.org/projects/nspr \
         --rev b09175587dad2bfb923ec87250ac80461f620577 \
    && hg clone https://hg.mozilla.org/projects/nss \
-        --rev 38a91427d65fffd0d7f7d2b6d0bcee7dc8b77a37 \
    && cd nss \
+   && hg pull -u -r 98542d9c204f8e91336f0a36239d776d82dc8989 https://hg.mozilla.org/projects/nss-try \
    && ./build.sh -Denable_draft_hpke=1 \
    && cd /
 

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# After typing Ctrl-C, Docker waits this number of seconds to interrupt the
+# containers.
+TIMEOUT=0
+
+if [ "$#" -ne 3 ]; then
+    echo "usage: $0 <client> <server> <testcase>"
+    echo
+    echo "where <client> and <server> are one of the following:"
+    echo "boringssl, cloudflare-go, nss, rustls"
+    echo
+    echo "and <testcase> is one of the following:"
+    echo "dc, ech-accept, ech-reject"
+    exit 1
+fi
+
+env SERVER_SRC=./impl-endpoints SERVER=$2 \
+    CLIENT_SRC=./impl-endpoints CLIENT=$1 \
+    TESTCASE=$3 \
+    docker-compose up --timeout $TIMEOUT
+
+docker-compose stop


### PR DESCRIPTION
This PR updates the NSS and Cloudflare-Go endpoints to run the latest draft of ECH. It also updates the test-input generation code accordingly.

DO NOT MERGE: Before merging, the following changes need to be made.
1. Remove build.sh and run.sh. These outdated test scripts are used to run the ECH test cases. (These aren't currently supported in the test runner.)
2. ~Revert change to impl-endpoint/cloudfflare-go/Dockerfile. Once https://github.com/cloudflare/go/pull/65 lands, update the file with the new commit.~
3. Revert change to impl-endpoint/nss/Dockerfile. Once https://phabricator.services.mozilla.com/D108392 lands, update the file with the new revision.

NOTE: This PR confirms interop of ECH-10 between NSS and Cloudflare-Go. To test the NSS client against the Cloudflare-Go server, do
```
make testinputs
./build.sh nss cloudflare-go
./run.sh nss cloudflare-go ech-accept
```
Replace "ech-accept" with "ech-reject" to exercise the rejection codepath. Swap "nss" and "cloudflare-go" to test the Cloudflare-Go client against the NSS server.

cc/ @martinthomson, @chris-wood 