### PR TITLE
Add results processing tool and stage to the interop workflow.

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 1
           path: go/src/github.com/${{ github.repository }}
       - name: Build test runner
-        run: make runner
+        run: make runner && make util
         working-directory: go/src/github.com/${{ github.repository }}
       - name: List interop endpoints
         id: set-endpoints
@@ -143,11 +143,14 @@ jobs:
           docker load --input tls-endpoint-${{ matrix.server }}.tar.gz
       - run: docker image ls
       - name: Build test runner
-        run: make runner
+        run: make runner && make util
         working-directory: go/src/github.com/${{ github.repository }}
       - name: Run tests
+        env:
+          TOKEN: ${{ secrets.RESULTSAPITOKEN }}
         run: |
           (./bin/runner --client=${{ matrix.client }} --server=${{ matrix.server }} --alltestcases || true)
+          (BEARER_TOKEN=$TOKEN ./bin/util -process-results -path=generated || true)
           mkdir -p logs/${{ matrix.client }}/${{ matrix.server }}
           mv generated/*-out logs/${{ matrix.client }}/${{ matrix.client }}/
         working-directory: go/src/github.com/${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ you must first build the necessary docker images ...
 ./bin/runner --client=boringssl --server=cloudflare-go --build
 ```
 
-
 3. You're now ready to run tests. For example, to run the server-side delegated credential
 test:
 

--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -99,7 +99,7 @@ func main() {
 			} else {
 				env = append(env, "SERVER_SRC=impl-endpoints")
 			}
-			env = append(env, fmt.Sprintf("SERVER=%s", client.name))
+			env = append(env, fmt.Sprintf("SERVER=%s", server.name))
 			cmd.Env = env
 			err := cmd.Run()
 			if err != nil {

--- a/cmd/runner/testcase.go
+++ b/cmd/runner/testcase.go
@@ -173,31 +173,31 @@ func (t *testCaseDC) run(client endpoint, server endpoint) error {
 	cmd.Stdout = &cmdOut
 	cmd.Stderr = &cmdOut
 
-	testLog, err := os.Create(filepath.Join(testOutputsDir, "test.txt"))
+	testStatusFile, err := os.Create(filepath.Join(testOutputsDir, "test.txt"))
 	if err != nil {
 		return &testError{err: fmt.Sprintf("os.Create failed: %s", err), funcName: fn.Name()}
 	}
 
 	err = cmd.Start()
 	if err != nil {
-		_, _ = testLog.WriteString(fmt.Sprintf("%s,%s,%s,%s", client.name, server.name, t.name, "error"))
+		_, _ = testStatusFile.WriteString(fmt.Sprintf("%s,%s,%s,%s", client.name, server.name, t.name, "error"))
 		return &testError{err: fmt.Sprintf("docker-compose up start(): %s", err), funcName: fn.Name()}
 	}
 
 	err = waitWithTimeout(cmd, t.timeout)
 	if err != nil {
 		if strings.Contains(err.Error(), "exit status 64") {
-			_, _ = testLog.WriteString(fmt.Sprintf("%s,%s,%s,%s", client.name, server.name, t.name, "skipped"))
+			_, _ = testStatusFile.WriteString(fmt.Sprintf("%s,%s,%s,%s", client.name, server.name, t.name, "skipped"))
 			return &testError{err: fmt.Sprintf("docker-compose up: %s", err), funcName: fn.Name(), unsupported: true}
 		}
-		_, _ = testLog.WriteString(fmt.Sprintf("%s,%s,%s,%s", client.name, server.name, t.name, "failed"))
+		_, _ = testStatusFile.WriteString(fmt.Sprintf("%s,%s,%s,%s", client.name, server.name, t.name, "failed"))
 		return &testError{err: fmt.Sprintf("docker-compose up: %s", err), funcName: fn.Name()}
 	}
 	if *verboseMode {
 		log.Println(cmdOut.String())
 	}
 
-	_, _ = testLog.WriteString(fmt.Sprintf("%s,%s,%s,%s", client.name, server.name, t.name, "success"))
+	_, _ = testStatusFile.WriteString(fmt.Sprintf("%s,%s,%s,%s", client.name, server.name, t.name, "success"))
 	runLog, err := os.Create(filepath.Join(testOutputsDir, "run.txt"))
 	if err != nil {
 		return &testError{err: fmt.Sprintf("os.Create failed: %s", err), funcName: fn.Name()}

--- a/cmd/runner/testcase.go
+++ b/cmd/runner/testcase.go
@@ -173,20 +173,31 @@ func (t *testCaseDC) run(client endpoint, server endpoint) error {
 	cmd.Stdout = &cmdOut
 	cmd.Stderr = &cmdOut
 
-	err := cmd.Start()
+	testLog, err := os.Create(filepath.Join(testOutputsDir, "test.txt"))
 	if err != nil {
+		return &testError{err: fmt.Sprintf("os.Create failed: %s", err), funcName: fn.Name()}
+	}
+
+	err = cmd.Start()
+	if err != nil {
+		_, _ = testLog.WriteString(fmt.Sprintf("%s,%s,%s,%s", client.name, server.name, t.name, "error"))
 		return &testError{err: fmt.Sprintf("docker-compose up start(): %s", err), funcName: fn.Name()}
 	}
+
 	err = waitWithTimeout(cmd, t.timeout)
 	if err != nil {
 		if strings.Contains(err.Error(), "exit status 64") {
+			_, _ = testLog.WriteString(fmt.Sprintf("%s,%s,%s,%s", client.name, server.name, t.name, "skipped"))
 			return &testError{err: fmt.Sprintf("docker-compose up: %s", err), funcName: fn.Name(), unsupported: true}
 		}
+		_, _ = testLog.WriteString(fmt.Sprintf("%s,%s,%s,%s", client.name, server.name, t.name, "failed"))
 		return &testError{err: fmt.Sprintf("docker-compose up: %s", err), funcName: fn.Name()}
 	}
 	if *verboseMode {
 		log.Println(cmdOut.String())
 	}
+
+	_, _ = testLog.WriteString(fmt.Sprintf("%s,%s,%s,%s", client.name, server.name, t.name, "success"))
 	runLog, err := os.Create(filepath.Join(testOutputsDir, "run.txt"))
 	if err != nil {
 		return &testError{err: fmt.Sprintf("os.Create failed: %s", err), funcName: fn.Name()}
@@ -195,6 +206,7 @@ func (t *testCaseDC) run(client endpoint, server endpoint) error {
 	if err != nil {
 		return &testError{err: fmt.Sprintf("WriteString failed: %s", err), funcName: fn.Name()}
 	}
+
 	return nil
 }
 

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -22,6 +22,7 @@ const usage = `Usage:
     $ util -make-dc -cert-in leaf.crt -key-in leaf.key -alg algorithm -out dc.txt
     $ util -make-ech-key -cert-in client-facing.crt -out ech_configs -key-out ech_key
     $ util -make-ech-key -cert-in client_facing.crt -out ech_configs -key-out ech_key
+    $ util -process-results -path /path/to/results
 
     Note: This is a barebones CLI intended for basic usage/debugging.
 `
@@ -33,7 +34,9 @@ func main() {
 		makeIntermediateCert = flag.Bool("make-intermediate", false, "")
 		makeDC               = flag.Bool("make-dc", false, "")
 		makeECH              = flag.Bool("make-ech", false, "")
+		processResults       = flag.Bool("process-results", false, "")
 		help                 = flag.Bool("help", false, "")
+		resultsPath          = flag.String("path", "", "")
 		inCertPath           = flag.String("cert-in", "", "")
 		inKeyPath            = flag.String("key-in", "", "")
 		outPath              = flag.String("out", "", "")
@@ -127,6 +130,14 @@ func main() {
 			*outPath,
 			*outKeyPath,
 		)
+		if err != nil {
+			log.Fatalf("ERROR: %s\n", err)
+		}
+	} else if *processResults && *resultsPath != "" {
+		err = utils.ProcessTestResults(*resultsPath)
+		if err != nil {
+			log.Fatalf("ERROR: %s\n", err)
+		}
 	} else {
 		fmt.Fprint(flag.CommandLine.Output(), usage)
 	}

--- a/internal/utils/post.go
+++ b/internal/utils/post.go
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2021 The tls-interop-runner Authors
+// SPDX-License-Identifier: MIT
+
+package utils
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+)
+
+const interopResultsURL = "https://tls-interop.crypto-team.workers.dev"
+
+func copyBearerToken() string {
+	var token string
+	if token = os.Getenv("BEARER_TOKEN"); len(token) == 0 {
+		token = "INVALID"
+	}
+	return token
+}
+
+func ProcessTestDirectory(dir string) error {
+	var client string
+	var server string
+	var testcase string
+	testData := make(map[string]string)
+
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, f := range files {
+		switch f.Name() {
+		case "test.txt":
+			data, err := ioutil.ReadFile(path.Join(dir, f.Name()))
+			if err != nil {
+				return err
+			}
+			params := strings.Split(string(data), ",")
+			client = params[0]
+			server = params[1]
+			testcase = params[2]
+			testData["result"] = params[3]
+		case "run.txt":
+			data, err := ioutil.ReadFile(path.Join(dir, f.Name()))
+			if err != nil {
+				return err
+			}
+			testData["run"] = string(data)
+		}
+	}
+
+	if len(client) == 0 || len(server) == 0 || len(testcase) == 0 {
+		return nil
+	}
+
+	encodedData, err := json.Marshal(testData)
+	if err != nil {
+		return err
+	}
+
+	url := interopResultsURL + "/upload-results?" + fmt.Sprintf("client=%s&server=%s&testcase=%s", client, server, testcase)
+	request, err := http.NewRequest("POST", url, bytes.NewBuffer(encodedData))
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("X-Upload-Bearer-Token", copyBearerToken())
+
+	httpClient := &http.Client{}
+	response, err := httpClient.Do(request)
+	if err != nil {
+		return err
+	}
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("Request failed with status code %d", response.StatusCode)
+	}
+
+	return nil
+}
+
+func ProcessTestResults(root string) error {
+	files, err := ioutil.ReadDir(root)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range files {
+		if f.IsDir() && strings.HasSuffix(f.Name(), "-out") {
+			err := ProcessTestDirectory(path.Join(root, f.Name()))
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Ready to go!

This change adds a new utility program to process the output of each interop test case and upload it to a remote server for storage. This will let us render the interop results (a la https://interop.seemann.io/) by querying the contents of the server.

<img width="1049" alt="Screen Shot 2021-03-19 at 3 05 20 PM" src="https://user-images.githubusercontent.com/2172048/111846685-903fcd00-88c4-11eb-8eb5-eff779fcdaeb.png">
