### PR TITLE
CI runner updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,18 +29,13 @@ runner: $(RUNNER_SRCS)
 	go get ./cmd/runner/...
 	go build -o ${RUNNER} ./cmd/runner/...
 
-# TODO(claucece): replace this makefile creation with golden files created by golang itself
-algorithms := 0x0807 0x0403 0x0503 0x0603
-r = $(shell awk -v min=1 -v max=3 'BEGIN{srand(); print int(min+rand()*(max-min+1))}')
-alg = $(word $(call r), $(algorithms))
-
 .PHONY: testinputs
 testinputs: util
 	mkdir -p ${TESTDATA_DIR}
 	${UTIL} -make-root -out ${TESTDATA_DIR}/root.crt -key-out ${TESTDATA_DIR}/root.key -host root.com
 	${UTIL} -make-intermediate -cert-in ${TESTDATA_DIR}/root.crt -key-in ${TESTDATA_DIR}/root.key -out ${TESTDATA_DIR}/example.crt -key-out ${TESTDATA_DIR}/example.key -host example.com
 	${UTIL} -make-intermediate -cert-in ${TESTDATA_DIR}/root.crt -key-in ${TESTDATA_DIR}/root.key -out ${TESTDATA_DIR}/client-facing.crt -key-out ${TESTDATA_DIR}/client-facing.key -host client-facing.com
-	${UTIL} -make-dc -cert-in ${TESTDATA_DIR}/example.crt -key-in ${TESTDATA_DIR}/example.key -alg $(call alg) -out ${TESTDATA_DIR}/dc.txt
+	${UTIL} -make-dc -cert-in ${TESTDATA_DIR}/example.crt -key-in ${TESTDATA_DIR}/example.key -out ${TESTDATA_DIR}/dc.txt
 	${UTIL} -make-ech -out ${TESTDATA_DIR}/ech_configs -key-out ${TESTDATA_DIR}/ech_key -host client-facing.com
 	${UTIL} -make-ech -out ${TESTDATA_DIR}/ech_configs_invalid -key-out /dev/null -host client-facing.com
 

--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -201,5 +201,5 @@ teardown:
 	if !allTestsMode {
 		return testcaseError
 	}
-    return nil
+	return nil
 }

--- a/cmd/runner/testcase.go
+++ b/cmd/runner/testcase.go
@@ -80,13 +80,11 @@ func (t *testCaseDC) setup() error {
 
 	var inputParams strings.Builder
 
-	rootSignatureAlgorithm := utils.SignatureECDSAWithP521AndSHA512
-	err = utils.MakeRootCertificate(
+	rootSignatureAlgorithm, err := utils.MakeRootCertificate(
 		&utils.Config{
 			Hostnames:          []string{"root.com"},
 			ValidFrom:          time.Now(),
 			ValidFor:           365 * 25 * time.Hour,
-			SignatureAlgorithm: rootSignatureAlgorithm,
 		},
 		filepath.Join(testInputsDir, "root.crt"),
 		filepath.Join(testInputsDir, "root.key"),
@@ -96,13 +94,11 @@ func (t *testCaseDC) setup() error {
 	}
 	inputParams.WriteString(fmt.Sprintf("Root certificate algorithm: 0x%X\n", rootSignatureAlgorithm))
 
-	intermediateSignatureAlgorithm := utils.SignatureECDSAWithP256AndSHA256
-	err = utils.MakeIntermediateCertificate(
+	intermediateSignatureAlgorithm, err := utils.MakeIntermediateCertificate(
 		&utils.Config{
 			Hostnames:          []string{"example.com"},
 			ValidFrom:          time.Now(),
 			ValidFor:           365 * 25 * time.Hour,
-			SignatureAlgorithm: intermediateSignatureAlgorithm,
 			ForDC:              true,
 		},
 		filepath.Join(testInputsDir, "root.crt"),
@@ -115,14 +111,11 @@ func (t *testCaseDC) setup() error {
 	}
 	inputParams.WriteString(fmt.Sprintf("Intermediate certificate algorithm: 0x%X\n", intermediateSignatureAlgorithm))
 
-	dcAlgorithm := utils.SignatureECDSAWithP256AndSHA256
 	dcValidFor := 24 * time.Hour
-	err = utils.MakeDelegatedCredential(
+	dcAlgorithm, err := utils.MakeDelegatedCredential(
 		&utils.Config{
 			ValidFor:           dcValidFor,
-			SignatureAlgorithm: dcAlgorithm,
 		},
-		&utils.Config{},
 		filepath.Join(testInputsDir, "example.crt"),
 		filepath.Join(testInputsDir, "example.key"),
 		filepath.Join(testInputsDir, "dc.txt"),
@@ -130,7 +123,7 @@ func (t *testCaseDC) setup() error {
 	if err != nil {
 		return err
 	}
-	inputParams.WriteString(fmt.Sprintf("Delegated credential algorithm: 0x%X\n", intermediateSignatureAlgorithm))
+	inputParams.WriteString(fmt.Sprintf("Delegated credential algorithm: 0x%X\n", dcAlgorithm))
 	inputParams.WriteString(fmt.Sprintf("DC valid for: %v\n", dcValidFor))
 
 	inputParamsLog, err := os.Create(filepath.Join(testOutputsDir, "input-params.txt"))

--- a/cmd/runner/testcase.go
+++ b/cmd/runner/testcase.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -40,7 +41,7 @@ func waitWithTimeout(cmd *exec.Cmd, timeout time.Duration) error {
 }
 
 type testCase interface {
-	setup() error
+	setup(verbose bool) (*os.File, error)
 	run(client endpoint, server endpoint) error
 	verify() error
 }
@@ -62,44 +63,56 @@ type testCaseDC struct {
 	name      string
 	timeout   time.Duration
 	outputDir string
+	logger    *log.Logger
 }
 
-func (t *testCaseDC) setup() error {
+func (t *testCaseDC) setup(verbose bool) (*os.File, error) {
 	err := os.MkdirAll(testInputsDir, os.ModePerm)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	err = os.RemoveAll(testOutputsDir)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	err = os.MkdirAll(testOutputsDir, os.ModePerm)
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	var inputParams strings.Builder
+	runLog, err := os.Create(filepath.Join(testOutputsDir, "run-log.txt"))
+	if err != nil {
+		return nil, err
+	}
+	if verbose {
+		t.logger = log.New(io.MultiWriter(os.Stdout, runLog),
+			"",
+			log.Ldate|log.Ltime|log.Lshortfile)
+	} else {
+		t.logger = log.New(io.Writer(runLog),
+			"",
+			log.Ldate|log.Ltime|log.Lshortfile)
+	}
 
 	rootSignatureAlgorithm, err := utils.MakeRootCertificate(
 		&utils.Config{
-			Hostnames:          []string{"root.com"},
-			ValidFrom:          time.Now(),
-			ValidFor:           365 * 25 * time.Hour,
+			Hostnames: []string{"root.com"},
+			ValidFrom: time.Now(),
+			ValidFor:  365 * 25 * time.Hour,
 		},
 		filepath.Join(testInputsDir, "root.crt"),
 		filepath.Join(testInputsDir, "root.key"),
 	)
 	if err != nil {
-		return err
+		return runLog, err
 	}
-	inputParams.WriteString(fmt.Sprintf("Root certificate algorithm: 0x%X\n", rootSignatureAlgorithm))
+	t.logger.Printf("Root certificate algorithm: 0x%X\n", rootSignatureAlgorithm)
 
 	intermediateSignatureAlgorithm, err := utils.MakeIntermediateCertificate(
 		&utils.Config{
-			Hostnames:          []string{"example.com"},
-			ValidFrom:          time.Now(),
-			ValidFor:           365 * 25 * time.Hour,
-			ForDC:              true,
+			Hostnames: []string{"example.com"},
+			ValidFrom: time.Now(),
+			ValidFor:  365 * 25 * time.Hour,
+			ForDC:     true,
 		},
 		filepath.Join(testInputsDir, "root.crt"),
 		filepath.Join(testInputsDir, "root.key"),
@@ -107,37 +120,26 @@ func (t *testCaseDC) setup() error {
 		filepath.Join(testInputsDir, "example.key"),
 	)
 	if err != nil {
-		return err
+		return runLog, err
 	}
-	inputParams.WriteString(fmt.Sprintf("Intermediate certificate algorithm: 0x%X\n", intermediateSignatureAlgorithm))
+	t.logger.Printf("Intermediate certificate algorithm: 0x%X\n", intermediateSignatureAlgorithm)
 
 	dcValidFor := 24 * time.Hour
 	dcAlgorithm, err := utils.MakeDelegatedCredential(
 		&utils.Config{
-			ValidFor:           dcValidFor,
+			ValidFor: dcValidFor,
 		},
 		filepath.Join(testInputsDir, "example.crt"),
 		filepath.Join(testInputsDir, "example.key"),
 		filepath.Join(testInputsDir, "dc.txt"),
 	)
 	if err != nil {
-		return err
+		return runLog, err
 	}
-	inputParams.WriteString(fmt.Sprintf("Delegated credential algorithm: 0x%X\n", dcAlgorithm))
-	inputParams.WriteString(fmt.Sprintf("DC valid for: %v\n", dcValidFor))
+	t.logger.Printf("Delegated credential algorithm: 0x%X\n", dcAlgorithm)
+	t.logger.Printf("DC valid for: %v\n", dcValidFor)
 
-	inputParamsLog, err := os.Create(filepath.Join(testOutputsDir, "input-params.txt"))
-	if err != nil {
-		return err
-	}
-	defer inputParamsLog.Close()
-
-	_, err = inputParamsLog.WriteString(inputParams.String())
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return runLog, nil
 }
 
 func (t *testCaseDC) run(client endpoint, server endpoint) error {
@@ -153,54 +155,40 @@ func (t *testCaseDC) run(client endpoint, server endpoint) error {
 	env = append(env, fmt.Sprintf("SERVER=%s", server.name))
 	env = append(env, fmt.Sprintf("CLIENT=%s", client.name))
 	env = append(env, fmt.Sprintf("TESTCASE=%s", t.name))
-
 	// SERVER_SRC and CLIENT_SRC should not be needed, since the images
-	// should be built and tagged by this point. They're just set to avoid
+	// should be built and tagged by this point. They're just set to suppress
 	// unset variable warnings by docker-compose.
 	env = append(env, "SERVER_SRC=\"\"")
 	env = append(env, "CLIENT_SRC=\"\"")
-
 	cmd.Env = env
 
 	var cmdOut bytes.Buffer
 	cmd.Stdout = &cmdOut
 	cmd.Stderr = &cmdOut
 
-	testStatusFile, err := os.Create(filepath.Join(testOutputsDir, "test.txt"))
+	err := cmd.Start()
 	if err != nil {
-		return &testError{err: fmt.Sprintf("os.Create failed: %s", err), funcName: fn.Name()}
-	}
-
-	err = cmd.Start()
-	if err != nil {
-		_, _ = testStatusFile.WriteString(fmt.Sprintf("%s,%s,%s,%s", client.name, server.name, t.name, "error"))
-		return &testError{err: fmt.Sprintf("docker-compose up start(): %s", err), funcName: fn.Name()}
+		err = &testError{err: fmt.Sprintf("docker-compose up start(): %s", err), funcName: fn.Name()}
+		goto runError
 	}
 
 	err = waitWithTimeout(cmd, t.timeout)
 	if err != nil {
 		if strings.Contains(err.Error(), "exit status 64") {
-			_, _ = testStatusFile.WriteString(fmt.Sprintf("%s,%s,%s,%s", client.name, server.name, t.name, "skipped"))
-			return &testError{err: fmt.Sprintf("docker-compose up: %s", err), funcName: fn.Name(), unsupported: true}
+			err = &testError{err: fmt.Sprintf("docker-compose up: %s", err), funcName: fn.Name(), unsupported: true}
 		}
-		_, _ = testStatusFile.WriteString(fmt.Sprintf("%s,%s,%s,%s", client.name, server.name, t.name, "failed"))
-		return &testError{err: fmt.Sprintf("docker-compose up: %s", err), funcName: fn.Name()}
-	}
-	if *verboseMode {
-		log.Println(cmdOut.String())
+		err = &testError{err: fmt.Sprintf("docker-compose up: %s", err), funcName: fn.Name()}
+		goto runError
 	}
 
-	_, _ = testStatusFile.WriteString(fmt.Sprintf("%s,%s,%s,%s", client.name, server.name, t.name, "success"))
-	runLog, err := os.Create(filepath.Join(testOutputsDir, "run.txt"))
-	if err != nil {
-		return &testError{err: fmt.Sprintf("os.Create failed: %s", err), funcName: fn.Name()}
-	}
-	_, err = runLog.WriteString(cmdOut.String())
-	if err != nil {
-		return &testError{err: fmt.Sprintf("WriteString failed: %s", err), funcName: fn.Name()}
-	}
-
+	t.logger.Print(cmdOut.String())
+	t.logger.Printf("%s completed without error.\n", fn.Name())
 	return nil
+
+runError:
+	t.logger.Println(cmdOut.String())
+	t.logger.Println(err)
+	return err
 }
 
 func (t *testCaseDC) verify() error {
@@ -209,20 +197,28 @@ func (t *testCaseDC) verify() error {
 
 	err := pcap.FindTshark()
 	if err != nil {
-		return &testError{err: fmt.Sprintf("tshark not found: %s", err), funcName: fn.Name()}
+		err = &testError{err: fmt.Sprintf("tshark not found: %s", err), funcName: fn.Name()}
+		t.logger.Println(err)
+		return err
 	}
 
 	pcapPath := filepath.Join(testOutputsDir, "client_node_trace.pcap")
 	keylogPath := filepath.Join(testOutputsDir, "client_keylog")
 	transcript, err := pcap.Parse(pcapPath, keylogPath)
 	if err != nil {
-		return &testError{err: fmt.Sprintf("could not parse pcap: %s", err), funcName: fn.Name()}
+		err = &testError{err: fmt.Sprintf("could not parse pcap: %s", err), funcName: fn.Name()}
+		t.logger.Println(err)
+		return err
 	}
 
 	err = pcap.Validate(transcript, t.name)
 	if err != nil {
-		return &testError{err: fmt.Sprintf("could not validate pcap: %s", err), funcName: fn.Name()}
+		err = &testError{err: fmt.Sprintf("could not validate pcap: %s", err), funcName: fn.Name()}
+		t.logger.Println(err)
+		return err
 	}
+
+	t.logger.Printf("%s completed without error.\n", fn.Name())
 	return nil
 }
 

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -133,7 +133,7 @@ func main() {
 			log.Fatalf("ERROR: %s\n", err)
 		}
 	} else if *processResults && *resultsPath != "" {
-        err := utils.ProcessTestResults(*resultsPath)
+		err := utils.ProcessTestResults(*resultsPath)
 		if err != nil {
 			log.Fatalf("ERROR: %s\n", err)
 		}

--- a/impl-endpoints/cloudflare-go/Dockerfile
+++ b/impl-endpoints/cloudflare-go/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
 RUN git clone https://github.com/cloudflare/go /cf
 
 WORKDIR /cf/src
-RUN git checkout 2a17ea31d28264fccfec4e59dc2ac733b6c73dec
+RUN git checkout 5ef1b90573f8742b763b7e65a43ce7fa20e37bb4
 RUN ./make.bash
 
 FROM ubuntu:20.04

--- a/impl-endpoints/cloudflare-go/run_endpoint.sh
+++ b/impl-endpoints/cloudflare-go/run_endpoint.sh
@@ -8,11 +8,7 @@ set -e
 sh /setup-routes.sh
 
 if [ "$ROLE" = "client" ]; then
-    echo "Running Cloudflare-Go client."
-    echo "Test case: $TESTCASE"
     runner -role=client -test=${TESTCASE}
 else
-    echo "Running Cloudflare-Go server."
-    echo "Test case: $TESTCASE"
     runner -role=server -test=${TESTCASE}
 fi

--- a/impl-endpoints/cloudflare-go/runner.go
+++ b/impl-endpoints/cloudflare-go/runner.go
@@ -160,13 +160,14 @@ func doClient(t TestHandler) error {
 	}
 
 	c, err := tls.Dial("tcp", "example.com:4433", config)
-	if err == nil {
-		defer c.Close()
+	if err != nil {
+		return err
 	}
+	defer c.Close()
 
 	err = t.ConnectionHandler(c, err)
 	if err != nil {
-		log.Print(err)
+		return err
 	}
 	return nil
 }

--- a/internal/utils/common.go
+++ b/internal/utils/common.go
@@ -12,57 +12,8 @@ package utils
 import (
 	"crypto/rand"
 	"io"
-	"math/big"
 	"time"
 )
-
-type dsaSignature struct {
-	R, S *big.Int
-}
-
-type ECDSASignature dsaSignature
-
-const (
-	// RSASSA-PKCS1-v1_5 algorithms
-	SignatureRSAPKCS1WithMD5    uint16 = 0x0101
-	SignatureRSAPKCS1WithSHA1   uint16 = 0x0201
-	SignatureRSAPKCS1WithSHA256 uint16 = 0x0401
-	SignatureRSAPKCS1WithSHA384 uint16 = 0x0501
-	SignatureRSAPKCS1WithSHA512 uint16 = 0x0601
-
-	// ECDSA algorithms
-	SignatureECDSAWithSHA1          uint16 = 0x0203
-	SignatureECDSAWithP256AndSHA256 uint16 = 0x0403
-	SignatureECDSAWithP384AndSHA384 uint16 = 0x0503
-	SignatureECDSAWithP521AndSHA512 uint16 = 0x0603
-
-	// RSASSA-PSS algorithms
-	SignatureRSAPSSWithSHA256 uint16 = 0x0804
-	SignatureRSAPSSWithSHA384 uint16 = 0x0805
-	SignatureRSAPSSWithSHA512 uint16 = 0x0806
-
-	// EdDSA algorithms
-	SignatureEd25519 uint16 = 0x0807
-	SignatureEd448   uint16 = 0x0808
-)
-
-type BadValue int
-
-const (
-	BadValueNone BadValue = iota
-	BadValueNegative
-	BadValueZero
-	BadValueLimit
-	BadValueLarge
-	NumBadValues
-)
-
-type CertificateBugs struct {
-	// BadECDSAR controls ways in which the 'r' value of an ECDSA signature
-	// can be invalid.
-	BadECDSAR BadValue
-	BadECDSAS BadValue
-}
 
 // Used to configure x509 certificates and DCs.
 type Config struct {
@@ -78,18 +29,13 @@ type Config struct {
 	ForClient bool
 	ForDC     bool
 
-	// Bugs specifies optional misbehaviour to be used for testing other
-	// implementations.
-	Bugs CertificateBugs
-
 	// SignatureAlgorithm defines the signature algorithm for certificates or delegated credentials
 	SignatureAlgorithm uint16
 }
 
 func (c *Config) rand() io.Reader {
-	r := c.Rand
-	if r == nil {
-		return rand.Reader
+	if c.Rand != nil {
+		return c.Rand
 	}
-	return r
+	return rand.Reader
 }

--- a/internal/utils/common.go
+++ b/internal/utils/common.go
@@ -27,7 +27,9 @@ type Config struct {
 	ValidFor  time.Duration
 
 	ForClient bool
-	ForDC     bool
+	EndEntity bool
+	// Note that ForDC implies EndEntity
+	ForDC bool
 
 	// SignatureAlgorithm defines the signature algorithm for certificates or delegated credentials
 	SignatureAlgorithm uint16

--- a/internal/utils/make.go
+++ b/internal/utils/make.go
@@ -241,12 +241,12 @@ func MakeDelegatedCredential(config *Config, inCertPath string, inKeyPath string
 	var dc []byte
 	// https://tools.ietf.org/html/draft-ietf-tls-subcerts-09#section-4
 	dc = append(dc, byte(lifetimeSecs>>24), byte(lifetimeSecs>>16), byte(lifetimeSecs>>8), byte(lifetimeSecs))
-	dc = append(dc, byte(config.SignatureAlgorithm>>8), byte(config.SignatureAlgorithm))
 
 	signer, err := getSigner(config.rand(), config.SignatureAlgorithm, true)
 	if err != nil {
 		return 0, err
 	}
+	dc = append(dc, byte(signer.algorithmID>>8), byte(signer.algorithmID))
 
 	priv, pub, err := signer.GenerateKey()
 	if err != nil {

--- a/internal/utils/make.go
+++ b/internal/utils/make.go
@@ -31,13 +31,7 @@ import (
 	"path/filepath"
 )
 
-// TODO(xvzcf): When passed to x509.CreateCertificate, RSA keys will result in
-// an RSA-PKCS1 certificate being generated since we have no control over how
-// priv.(*crypto.Signer).Sign() is called in that function. This means we currently
-// cannot support RSA-PSS. x509.CreateCertificate also makes it hard to do
-// certificate fuzzing.
-// The solution might just be to reproduce the implementation of
-// x509.CreateCertificate here with appropriate modifications.
+// TODO(xvzcf): Support RSA-PSS and discuss how to approach fuzzing.
 
 // MakeRootCertificate is based on code found in https://github.com/FiloSottile/mkcert
 func MakeRootCertificate(config *Config, outPath string, outKeyPath string) (uint16, error) {

--- a/internal/utils/make.go
+++ b/internal/utils/make.go
@@ -300,7 +300,7 @@ func MakeDelegatedCredential(config *Config, inCertPath string, inKeyPath string
 		} else if curveName == "P-521" {
 			parentSigAlg = SignatureECDSAWithP521AndSHA512
 		} else {
-			return 0, errors.New("public key unsupported\n")
+			return 0, errors.New("public key unsupported")
 		}
 	case ed25519.PublicKey:
 		parentSigAlg = SignatureEd25519
@@ -313,10 +313,10 @@ func MakeDelegatedCredential(config *Config, inCertPath string, inKeyPath string
 		} else if bits == 4096 {
 			parentSigAlg = SignatureRSAPKCS1WithSHA512
 		} else {
-			return 0, errors.New("error parsing RSA key.")
+			return 0, errors.New("error parsing RSA key")
 		}
 	default:
-		return 0, errors.New("public key unsupported\n")
+		return 0, errors.New("public key unsupported")
 	}
 	dc = append(dc, byte(parentSigAlg>>8), byte(parentSigAlg))
 

--- a/internal/utils/post.go
+++ b/internal/utils/post.go
@@ -46,7 +46,7 @@ func ProcessTestDirectory(dir string) error {
 			server = params[1]
 			testcase = params[2]
 			testData["result"] = params[3]
-		case "run.txt":
+		case "run-log.txt":
 			data, err := ioutil.ReadFile(path.Join(dir, f.Name()))
 			if err != nil {
 				return err

--- a/internal/utils/sign.go
+++ b/internal/utils/sign.go
@@ -148,7 +148,7 @@ func getSigner(randReader io.Reader, sigAlg uint16, selectValidDCAlg bool) (*Sig
 		if err != nil {
 			return nil, err
 		}
-		sigAlg = sigAlgList[int(buf[0])%len(sigAlgList)]
+		sigAlg = sigAlgList[int(buf[0]) % len(sigAlgList)]
 	}
 	switch sigAlg {
 	case SignatureECDSAWithP256AndSHA256:

--- a/internal/utils/sign.go
+++ b/internal/utils/sign.go
@@ -148,7 +148,7 @@ func getSigner(randReader io.Reader, sigAlg uint16, selectValidDCAlg bool) (*Sig
 		if err != nil {
 			return nil, err
 		}
-		sigAlg = sigAlgList[int(buf[0]) % len(sigAlgList)]
+		sigAlg = sigAlgList[int(buf[0])%len(sigAlgList)]
 	}
 	switch sigAlg {
 	case SignatureECDSAWithP256AndSHA256:

--- a/internal/utils/sign.go
+++ b/internal/utils/sign.go
@@ -14,57 +14,72 @@ import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
+	"crypto/rsa"
 	"fmt"
 	"io"
 )
 
+const (
+	// RSASSA-PKCS1-v1_5 algorithms
+	SignatureRSAPKCS1WithMD5    uint16 = 0x0101
+	SignatureRSAPKCS1WithSHA1   uint16 = 0x0201
+	SignatureRSAPKCS1WithSHA256 uint16 = 0x0401
+	SignatureRSAPKCS1WithSHA384 uint16 = 0x0501
+	SignatureRSAPKCS1WithSHA512 uint16 = 0x0601
+
+	// ECDSA algorithms
+	SignatureECDSAWithP256AndSHA256 uint16 = 0x0403
+	SignatureECDSAWithP384AndSHA384 uint16 = 0x0503
+	SignatureECDSAWithP521AndSHA512 uint16 = 0x0603
+
+	// EdDSA algorithms
+	SignatureEd25519 uint16 = 0x0807
+)
+
+const (
+	SignatureTypeECDSA    uint = iota
+	SignatureTypeEd25519  uint = iota
+	SignatureTypeRSAPKCS1 uint = iota
+)
+
 // Signer represents an structure holding the signing information
 type Signer struct {
-	bugs  *CertificateBugs
-	curve elliptic.Curve
-	hash  crypto.Hash
-	priv  crypto.PrivateKey
-	rand  io.Reader
-	ecdsa bool
-}
-
-func maybeCorruptECDSASignature(typeOfCorruption BadValue, signature []byte) []byte {
-	switch typeOfCorruption {
-	case BadValueNone:
-		return signature
-	case BadValueZero:
-		signature = nil
-		return signature
-	case BadValueLarge:
-		signature = append(signature, 0)
-		return signature
-	default:
-		panic("unknown corruption type")
-	}
+	algorithmID   uint16
+	signatureType uint
+	rand          io.Reader
+	hash          crypto.Hash
+	priv          crypto.PrivateKey
+	curve         elliptic.Curve
+	rsaBits       int
 }
 
 // GenerateKey generates a public and private key pair.
-// TODO(claucece): as this is used beyond DCs, it needs to support all the other algos.
 func (e *Signer) GenerateKey() (crypto.PrivateKey, crypto.PublicKey, error) {
 	var privK crypto.PrivateKey
 	var pubK crypto.PublicKey
 	var err error
 
-	if e.ecdsa == true {
+	switch e.signatureType {
+	case SignatureTypeECDSA:
 		privK, err = ecdsa.GenerateKey(e.curve, e.rand)
 		if err != nil {
 			return nil, nil, err
 		}
 		pubK = privK.(*ecdsa.PrivateKey).Public()
-	} else {
+	case SignatureTypeEd25519:
 		pubK, privK, err = ed25519.GenerateKey(e.rand)
 		if err != nil {
 			return nil, nil, err
 		}
+	case SignatureTypeRSAPKCS1:
+		privK, err = rsa.GenerateKey(e.rand, e.rsaBits)
+		if err != nil {
+			return nil, nil, err
+		}
+		pubK = privK.(*rsa.PrivateKey).Public()
 	}
-
 	e.priv = privK
-	return privK, pubK, err
+	return privK, pubK, nil
 }
 
 var directSigning crypto.Hash = 0
@@ -94,26 +109,66 @@ func (e *Signer) SignWithKey(key crypto.PrivateKey, msg []byte) ([]byte, error) 
 		if err != nil {
 			return nil, err
 		}
+	case rsa.PrivateKey:
+		if e.signatureType == SignatureTypeRSAPKCS1 {
+			opts := crypto.SignerOpts(e.hash)
+			sig, err = sk.Sign(e.rand, msg, opts)
+		} else {
+			opts := &rsa.PSSOptions{Hash: e.hash}
+			sig, err = sk.Sign(e.rand, msg, opts)
+		}
+		if err != nil {
+			return nil, err
+		}
 	default:
-		return nil, fmt.Errorf("tls: unsupported key type")
+		return nil, fmt.Errorf("unsupported key type")
 	}
 
 	return sig, nil
 }
 
 // TODO(claucece): as this is used beyond DCs, it needs to support all the other algos.
-func getSigner(bugs *CertificateBugs, rand io.Reader, sigAlg uint16) (*Signer, error) {
+func getSigner(randReader io.Reader, sigAlg uint16, selectValidDCAlg bool) (*Signer, error) {
+	if sigAlg == 0 { // Choose one at random
+		sigAlgList := []uint16{SignatureECDSAWithP256AndSHA256,
+			SignatureECDSAWithP384AndSHA384,
+			SignatureECDSAWithP521AndSHA512,
+			SignatureEd25519}
+		if !selectValidDCAlg {
+			sigAlgList = append(sigAlgList,
+				[]uint16{SignatureRSAPKCS1WithMD5,
+					SignatureRSAPKCS1WithSHA1,
+					SignatureRSAPKCS1WithSHA256,
+					SignatureRSAPKCS1WithSHA384,
+					SignatureRSAPKCS1WithSHA512}...)
+		}
+
+		buf := make([]byte, 1)
+		_, err := randReader.Read(buf)
+		if err != nil {
+			return nil, err
+		}
+		sigAlg = sigAlgList[int(buf[0])%len(sigAlgList)]
+	}
 	switch sigAlg {
-	case SignatureECDSAWithSHA1:
-		return &Signer{bugs, nil, crypto.SHA1, nil, rand, true}, nil
 	case SignatureECDSAWithP256AndSHA256:
-		return &Signer{bugs, elliptic.P256(), crypto.SHA256, nil, rand, true}, nil
+		return &Signer{SignatureECDSAWithP256AndSHA256, SignatureTypeECDSA, randReader, crypto.SHA256, nil, elliptic.P256(), 0}, nil
 	case SignatureECDSAWithP384AndSHA384:
-		return &Signer{bugs, elliptic.P384(), crypto.SHA384, nil, rand, true}, nil
+		return &Signer{SignatureECDSAWithP384AndSHA384, SignatureTypeECDSA, randReader, crypto.SHA384, nil, elliptic.P384(), 0}, nil
 	case SignatureECDSAWithP521AndSHA512:
-		return &Signer{bugs, elliptic.P521(), crypto.SHA512, nil, rand, true}, nil
+		return &Signer{SignatureECDSAWithP521AndSHA512, SignatureTypeECDSA, randReader, crypto.SHA512, nil, elliptic.P521(), 0}, nil
 	case SignatureEd25519:
-		return &Signer{bugs, nil, directSigning, nil, rand, false}, nil
+		return &Signer{SignatureEd25519, SignatureTypeEd25519, randReader, directSigning, nil, nil, 0}, nil
+	case SignatureRSAPKCS1WithMD5:
+		return &Signer{SignatureRSAPKCS1WithMD5, SignatureTypeRSAPKCS1, randReader, crypto.MD5, nil, nil, 2048}, nil
+	case SignatureRSAPKCS1WithSHA1:
+		return &Signer{SignatureRSAPKCS1WithSHA1, SignatureTypeRSAPKCS1, randReader, crypto.SHA1, nil, nil, 2048}, nil
+	case SignatureRSAPKCS1WithSHA256:
+		return &Signer{SignatureRSAPKCS1WithSHA256, SignatureTypeRSAPKCS1, randReader, crypto.SHA1, nil, nil, 2048}, nil
+	case SignatureRSAPKCS1WithSHA384:
+		return &Signer{SignatureRSAPKCS1WithSHA384, SignatureTypeRSAPKCS1, randReader, crypto.SHA1, nil, nil, 3072}, nil
+	case SignatureRSAPKCS1WithSHA512:
+		return &Signer{SignatureRSAPKCS1WithSHA512, SignatureTypeRSAPKCS1, randReader, crypto.SHA1, nil, nil, 4096}, nil
 	}
 
 	return nil, fmt.Errorf("unsupported signature algorithm %04x", sigAlg)


### PR DESCRIPTION
- Added ability to randomize signature algorithm selection for certificates and DCs (done by passing the `-alg 0` flag, which is also the default if `-alg` isn't specified).
- Removed fuzzing stuff, since that'll have to be thought out more
- Logging is done verbosely to a log file called `generated/test-outputs/run-log.txt`, can also be written to stdout if the `--verbose` flag is passed to the runner. `docker-compose build` output will written to stdout if `--verbose` is passed, but is not at all written to `run-log.txt`
- `impl-endpoints/cloudflare-go/runner.go` had a small bug that would let the client exit successfully even when there's an error

Up next after this PR: Adding a BoringSSL client and a client-auth-via-DC testcase 